### PR TITLE
Simpler settings management

### DIFF
--- a/sorl/thumbnail/conf/__init__.py
+++ b/sorl/thumbnail/conf/__init__.py
@@ -1,19 +1,19 @@
 from django.conf import settings as user_settings
-from django.utils.functional import LazyObject
 from sorl.thumbnail.conf import defaults
 
 
-class Settings(object):
-    pass
+class Settings:
+    """
+    Settings proxy that will lookup first in the django settings, and then in the conf
+    defaults.
+    """
+    def __getattr__(self, name):
+        if name != name.upper():
+            raise AttributeError(name)
+        try:
+            return getattr(user_settings, name)
+        except AttributeError:
+            return getattr(defaults, name)
 
 
-class LazySettings(LazyObject):
-    def _setup(self):
-        self._wrapped = Settings()
-        for obj in (defaults, user_settings):
-            for attr in dir(obj):
-                if attr == attr.upper():
-                    setattr(self, attr, getattr(obj, attr))
-
-
-settings = LazySettings()
+settings = Settings()

--- a/tests/thumbnail_tests/test_templatetags.py
+++ b/tests/thumbnail_tests/test_templatetags.py
@@ -5,12 +5,13 @@ from PIL import Image
 
 from django.template.loader import render_to_string
 from django.test import Client, TestCase
+from django.test.utils import override_settings
 import pytest
 
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.pil_engine import Engine as PILEngine
 from .models import Item
-from .utils import BaseTestCase, override_custom_settings, DATA_DIR
+from .utils import BaseTestCase, DATA_DIR
 
 
 pytestmark = pytest.mark.django_db
@@ -136,7 +137,7 @@ class TemplateTestCaseB(BaseTestCase):
 
 class TemplateTestCaseClient(TestCase):
     def test_empty_error(self):
-        with override_custom_settings(settings, THUMBNAIL_DEBUG=False):
+        with override_settings(THUMBNAIL_DEBUG=False):
             from django.core.mail import outbox
 
             client = Client()

--- a/tests/thumbnail_tests/utils.py
+++ b/tests/thumbnail_tests/utils.py
@@ -6,8 +6,6 @@ from contextlib import contextmanager
 from subprocess import check_output
 
 from PIL import Image, ImageDraw
-from django.test.signals import setting_changed
-from django.conf import UserSettingsHolder
 
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import get_module_class
@@ -46,41 +44,6 @@ def get_open_fds_count():
         [s for s in procs.decode('utf-8').split('\n') if s and s[0] == 'f' and s[1:].isdigit()]
     )
     return nprocs
-
-
-class override_custom_settings(object):
-    """
-    settings overrider context manager.
-    https://github.com/django/django/blob/1.6.2/django/test/utils.py#L209-L268
-    """
-
-    def __init__(self, settings_obj, **kwargs):
-        self.settings = settings_obj
-        self.options = kwargs
-
-    def __enter__(self):
-        self.enable()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.disable()
-
-    def enable(self):
-        override = UserSettingsHolder(self.settings._wrapped)
-        for key, new_value in self.options.items():
-            setattr(override, key, new_value)
-        self.wrapped = self.settings._wrapped
-        self.settings._wrapped = override
-        for key, new_value in self.options.items():
-            setting_changed.send(sender=self.settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=True)
-
-    def disable(self):
-        self.settings._wrapped = self.wrapped
-        del self.wrapped
-        for key in self.options:
-            new_value = getattr(self.settings, key, None)
-            setting_changed.send(sender=self.settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=False)
 
 
 class FakeFile(object):


### PR DESCRIPTION
The previous settings structure was causing the loading of all django
settings, including those that are deprecated. This was causing
deprecation warnings for most users. These warnings could be disabled at
the cost of hiding all django deprecation warnings, which was too bad.

We took the opportunity to get rid of a now useless test utility:
"override_custom_settings".

Close #589.